### PR TITLE
Adjust XmlTextReader construction

### DIFF
--- a/src/TurboXml.Bench/BenchStream.cs
+++ b/src/TurboXml.Bench/BenchStream.cs
@@ -72,7 +72,7 @@ public class BenchStream
         foreach (var stream in _streams)
         {
             stream.Position = 0;
-            var reader = new XmlTextReader(new StreamReader(stream));
+            var reader = new XmlTextReader(stream);
             while (reader.Read())
             {
                 switch (reader.NodeType)


### PR DESCRIPTION
Having tried to push System.Xml.XmlReader to its limits before, I've noticed that it is particularly sensitive to the buffering of the IO layers. 

Before

| Method                              | Mean      | Error     | StdDev    | Gen0      | Gen1    | Allocated  |
|------------------------------------ |----------:|----------:|----------:|----------:|--------:|-----------:|
| 'TurboXml - Stream'                 |  7.064 ms | 0.1397 ms | 0.0731 ms |         - |       - |   13.23 KB |
| 'TurboXml - Stream - SIMD Disabled' |  9.009 ms | 0.3774 ms | 0.1974 ms |         - |       - |    13.2 KB |
| 'XmlReader - Stream'                | 13.520 ms | 0.2996 ms | 0.1330 ms | 1500.0000 | 15.6250 | 6147.54 KB |

After

| Method                              | Mean     | Error     | StdDev    | Gen0      | Allocated  |
|------------------------------------ |---------:|----------:|----------:|----------:|-----------:|
| 'TurboXml - Stream'                 | 7.042 ms | 0.1163 ms | 0.0415 ms |         - |   13.19 KB |
| 'TurboXml - Stream - SIMD Disabled' | 8.838 ms | 0.0664 ms | 0.0103 ms |         - |   13.28 KB |
| 'XmlReader - Stream'                | 8.986 ms | 0.1074 ms | 0.0166 ms | 1312.5000 | 5415.58 KB |

A similar difference can be seen by instead changing:

```
_streams.Add(new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, 0));
```
to:
```
_streams.Add(new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, 0x8000));
```

I'm not sure exactly where the bottleneck is introduced, but it looks like the current config is not giving XmlTextReader its full potential.