### PR TITLE
Multi-target .NET 8 and .NET 9

### DIFF
--- a/src/TurboXml.Bench/TurboXml.Bench.csproj
+++ b/src/TurboXml.Bench/TurboXml.Bench.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TurboXml.CodeGen/TurboXml.CodeGen.csproj
+++ b/src/TurboXml.CodeGen/TurboXml.CodeGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/TurboXml.Tests/TurboXml.Tests.csproj
+++ b/src/TurboXml.Tests/TurboXml.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>net8.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.2.0" />
-    <PackageReference Include="Verify.MSTest" Version="23.1.0" />
+    <PackageReference Include="MSTest" Version="3.8.0" />
+    <PackageReference Include="Verify.MSTest" Version="28.10.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TurboXml.sln
+++ b/src/TurboXml.sln
@@ -14,7 +14,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitignore = ..\.gitignore
 		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
 		dotnet-releaser.toml = dotnet-releaser.toml
-		global.json = global.json
 		..\license.txt = ..\license.txt
 		..\readme.md = ..\readme.md
 	EndProjectSection

--- a/src/TurboXml/TurboXml.csproj
+++ b/src/TurboXml/TurboXml.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <!-- Enable AOT analyzers -->
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="4.3.0">
+    <PackageReference Include="MinVer" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/global.json
+++ b/src/global.json
@@ -1,7 +1,0 @@
-{
-    "sdk": {
-        "version": "8.0.100",
-        "rollForward": "latestMinor",
-        "allowPrerelease": false
-    }
-}


### PR DESCRIPTION
This PR adds multi-targeting of .NET 8 and .NET 9.

Since global.json only allows defining one framework, I had to remove it to prevent conflicts with both targeted frameworks.