### PR TITLE
support unseekable streams: skip encoding detection

### DIFF
--- a/src/TurboXml/StreamCharProvider.cs
+++ b/src/TurboXml/StreamCharProvider.cs
@@ -33,19 +33,23 @@ internal struct StreamCharProvider : ICharProvider, IDisposable
         _index = 0;
         _bufferOffset = 0;
 
-        var detectedEncoding = DetectEncodingOrNull(stream, out var offset);
-        if (detectedEncoding != null)
+        if (encoding is null)
         {
-            encoding ??= detectedEncoding;
+            var detectedEncoding = DetectEncodingOrNull(stream, out var offset);
+            if (detectedEncoding != null)
+            {
+                encoding ??= detectedEncoding;
+            }
+
+            encoding ??= Encoding.UTF8;
+            if (offset > 0)
+            {
+                _stream.Position += offset;
+            }
         }
-        encoding ??= Encoding.UTF8;
 
         _decoder = encoding.GetDecoder();
         _text = ArrayPool<char>.Shared.Rent(encoding.GetMaxCharCount(_buffer.Length));
-        if (offset > 0)
-        {
-            _stream.Position += offset;
-        }
     }
 
     public bool TryReadNext(out char c)


### PR DESCRIPTION
DetectEncodingOrNull requires a seekable stream. Encoding detection requires reading the first four bytes. The stream is advanced, then rewound. Fine for a FileStream, but not for a DeflateStream, as when the xml is being read with System.IO.Compression.ZipArchive.

SO. If the caller has provided an encoding: use it, skip trying to suss out the actual stream encoding, and absolutely avoid writing to the position property of the stream.