### PR TITLE
Add processing instruction callbacks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
 This parser is following the [Extensible Markup Language (XML) 1.0 (Fifth Edition)](https://www.w3.org/TR/xml/) and **should support any XML valid documents**, except for the known limitations described below:
 
 - For simplicity of the implementation, this parser does not support DTD, custom entities and XML directives (`<!DOCTYPE ...>`). If you are looking for this, you should instead use `System.Xml.XmlReader`.
-- Generic processing instructions such as `<?xpacket ...?>` or `<?xml-stylesheet ...?>` are accepted and ignored. Only the XML declaration `<?xml ...?>` triggers `IXmlReadHandler.OnXmlDeclaration`.
+- Generic processing instructions such as `<?xpacket ...?>` or `<?xml-stylesheet ...?>` trigger `IXmlReadHandler.OnProcessingInstruction`. Its default implementation is empty, so existing handlers continue to ignore them. The `data` callback parameter preserves the raw source after the target, including separating whitespace. Only the XML declaration `<?xml ...?>` triggers `IXmlReadHandler.OnXmlDeclaration`.
 - This parser checks for well formed XML, matching begin and end tags and report an error if they are not matching
 - This parser does not check for duplicated attributes.
   - It is the responsibility of the XML handler to implement such a check. The rationale is that the check can be performed more efficiently depending on user scenarios (e.g bit flags...etc.)

--- a/src/TurboXml.Tests/XmlRuntimeTests.cs
+++ b/src/TurboXml.Tests/XmlRuntimeTests.cs
@@ -78,6 +78,71 @@ public class XmlRuntimeTests
     }
 
     [TestMethod]
+    public void TestProcessingInstructionDataCanReconstructSource()
+    {
+        const string xml = "<?custom \tdata?\r\nhere?>";
+        var handler = new ProcessingInstructionHandler();
+
+        XmlParser.Parse(xml, handler);
+
+        Assert.HasCount(1, handler.Instructions);
+        var instruction = handler.Instructions[0];
+        Assert.AreEqual("custom", instruction.Target);
+        Assert.AreEqual(" \tdata?\r\nhere", instruction.Data);
+        Assert.AreEqual(xml, $"<?{instruction.Target}{instruction.Data}?>");
+        Assert.AreEqual(0, instruction.Line);
+        Assert.AreEqual(1, instruction.Column);
+    }
+
+    [TestMethod]
+    public void TestProcessingInstructionWithoutDataIsReported()
+    {
+        var handler = new ProcessingInstructionHandler();
+
+        XmlParser.Parse("<?before?>", handler);
+
+        Assert.HasCount(1, handler.Instructions);
+        Assert.AreEqual("before", handler.Instructions[0].Target);
+        Assert.AreEqual(string.Empty, handler.Instructions[0].Data);
+    }
+
+    [TestMethod]
+    public void TestProcessingInstructionInsideElementIsReported()
+    {
+        var handler = new ProcessingInstructionHandler();
+
+        XmlParser.Parse("""<root><?custom keep="data"?><child /></root>""", handler);
+
+        CollectionAssert.AreEqual(new[] { "root", "child" }, handler.BeginTags);
+        Assert.HasCount(1, handler.Instructions);
+        Assert.AreEqual("custom", handler.Instructions[0].Target);
+        Assert.AreEqual(" keep=\"data\"", handler.Instructions[0].Data);
+    }
+
+    [TestMethod]
+    public void TestMalformedProcessingInstructionIsRejected()
+    {
+        var result = ParseEvents("<root><?custom!?></root>");
+        var expecting = """
+                        BeginTag(root)
+                        Error(Invalid processing instruction. Expecting whitespace or ?> after the target)
+                        """;
+
+        Assert.AreEqual(NormalizeNewLines(expecting), result);
+    }
+
+    [TestMethod]
+    public void TestXmlDeclarationDoesNotReportProcessingInstruction()
+    {
+        var handler = new ProcessingInstructionHandler();
+
+        XmlParser.Parse("""<?xml version="1.0"?><root/>""", handler);
+
+        Assert.AreEqual(1, handler.XmlDeclarationCount);
+        Assert.IsEmpty(handler.Instructions);
+    }
+
+    [TestMethod]
     public void TestXmlDeclarationMustRemainFirstAfterProcessingInstruction()
     {
         var xml = """<?xpacket begin="id"?><?xml version="1.0"?><root/>""";
@@ -408,4 +473,24 @@ public class XmlRuntimeTests
         public void OnError(string message, int line, int column)
             => Writer.WriteLine($"Error({message})");
     }
+
+    private sealed class ProcessingInstructionHandler : IXmlReadHandler
+    {
+        public List<ProcessingInstruction> Instructions { get; } = [];
+
+        public List<string> BeginTags { get; } = [];
+
+        public int XmlDeclarationCount { get; private set; }
+
+        public void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone, int line, int column)
+            => XmlDeclarationCount++;
+
+        public void OnProcessingInstruction(ReadOnlySpan<char> target, ReadOnlySpan<char> data, int line, int column)
+            => Instructions.Add(new ProcessingInstruction(target.ToString(), data.ToString(), line, column));
+
+        public void OnBeginTag(ReadOnlySpan<char> name, int line, int column)
+            => BeginTags.Add(name.ToString());
+    }
+
+    private readonly record struct ProcessingInstruction(string Target, string Data, int Line, int Column);
 }

--- a/src/TurboXml/IXmlReadHandler.cs
+++ b/src/TurboXml/IXmlReadHandler.cs
@@ -25,6 +25,20 @@ public interface IXmlReadHandler
     }
 
     /// <summary>
+    /// Called when a processing instruction other than an XML declaration has been parsed.
+    /// </summary>
+    /// <param name="target">The processing instruction target.</param>
+    /// <param name="data">The raw source text after <paramref name="target"/> and before <c>?&gt;</c>, including any separating whitespace.</param>
+    /// <param name="line">The line this processing instruction occurred.</param>
+    /// <param name="column">The column this processing instruction occurred.</param>
+    /// <remarks>
+    /// The processing instruction can be reconstructed exactly as <c>&lt;?</c><paramref name="target"/><paramref name="data"/><c>?&gt;</c>.
+    /// </remarks>
+    void OnProcessingInstruction(ReadOnlySpan<char> target, ReadOnlySpan<char> data, int line, int column)
+    {
+    }
+
+    /// <summary>
     /// Called when an open tag is parsed.
     /// </summary>
     /// <param name="name">The name of the tag.</param>

--- a/src/TurboXml/XmlParserInternal.cs
+++ b/src/TurboXml/XmlParserInternal.cs
@@ -894,10 +894,12 @@ internal ref struct XmlParserInternal
 
         char c = ReadNext();
 
+        var targetStart = _length;
         if (!TryParseName(ref c))
             ThrowInvalidXml(XmlThrow.InvalidProcessingInstructionExpectingXml);
 
-        var target = GetTextSpan();
+        var targetLength = _length - targetStart;
+        var target = GetTextSpan(targetStart).Slice(0, targetLength);
         if (target.SequenceEqual("xml".AsSpan()))
         {
             if (_xmlParsingBody)
@@ -916,12 +918,26 @@ internal ref struct XmlParserInternal
             ThrowInvalidXml(XmlThrow.InvalidProcessingInstructionExpectingXml);
         }
 
-        ClearCharacterBuffer();
-        ParseProcessingInstruction(ref c);
+        ParseProcessingInstruction(targetStart, targetLength, startLine, startColumn, ref c);
     }
 
-    private void ParseProcessingInstruction(ref char c)
+    private void ParseProcessingInstruction(int targetStart, int targetLength, int startLine, int startColumn, ref char c)
     {
+        var dataStart = _length;
+        var hasDataSeparator = XmlChar.IsWhiteSpace(c);
+        if (c == '?')
+        {
+            c = ReadNext();
+            if (c == '>')
+            {
+                _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), ReadOnlySpan<char>.Empty, startLine, startColumn);
+                ClearCharacterBuffer();
+                return;
+            }
+
+            AppendCharacter('?');
+        }
+
         while (true)
         {
         ProcessNextChar:
@@ -931,14 +947,20 @@ internal ref struct XmlParserInternal
                     c = ReadNext();
                     if (c == '>')
                     {
+                        if (!hasDataSeparator)
+                            ThrowInvalidXml(XmlThrow.InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan);
+
+                        _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), GetTextSpan(dataStart), startLine, startColumn);
                         ClearCharacterBuffer();
                         return;
                     }
 
+                    AppendCharacter('?');
                     goto ProcessNextChar;
                 case '\n':
                     _line++;
                     _column = -1;
+                    AppendCharacter(c);
                     break;
                 case '\r':
                     if (!TryReadNext(out c))
@@ -948,10 +970,13 @@ internal ref struct XmlParserInternal
                     if (c == '\n')
                     {
                         _column = -1;
+                        AppendCharacter('\r');
+                        AppendCharacter(c);
                     }
                     else
                     {
                         _column = 0;
+                        AppendCharacter('\r');
                         goto ProcessNextChar;
                     }
 
@@ -959,12 +984,14 @@ internal ref struct XmlParserInternal
                 default:
                     if (XmlChar.IsChar(c))
                     {
+                        AppendCharacter(c);
                         break;
                     }
 
                     if (char.IsHighSurrogate(c))
                     {
-                        ReadLowSurrogate();
+                        AppendCharacter(c);
+                        AppendCharacter(ReadLowSurrogate());
                         break;
                     }
 

--- a/src/TurboXml/XmlThrowHelper.cs
+++ b/src/TurboXml/XmlThrowHelper.cs
@@ -44,7 +44,8 @@ internal enum XmlThrow
     InvalidCharacterFoundAfterStandaloneExpectingEqual,
     InvalidCharacterFoundExpectingQuestionGreaterThan,
     InvalidEndOfXMLStream,
-    InvalidCharacterFoundExpectingLowSurrogate
+    InvalidCharacterFoundExpectingLowSurrogate,
+    InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan
 }
 
 internal static class XmlThrowHelper
@@ -99,6 +100,7 @@ internal static class XmlThrowHelper
             XmlThrow.InvalidCharacterFoundExpectingQuestionGreaterThan => "Invalid character after processing instruction attributes. Expecting ?>",
             XmlThrow.InvalidEndOfXMLStream => "Invalid end of XML stream",
             XmlThrow.InvalidCharacterFoundExpectingLowSurrogate => "Invalid character found. Expecting a low surrogate",
+            XmlThrow.InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan => "Invalid processing instruction. Expecting whitespace or ?> after the target",
             _ => "Unexpected XML parsing error"
         };
     }


### PR DESCRIPTION
## Summary

TurboXml currently recognizes generic processing instructions (PIs) for well-formedness, but silently discards them. This prevents handler-based consumers from preserving unmodeled XML extension content when they need to capture and later reproduce it.

This PR adds a backward-compatible `IXmlReadHandler.OnProcessingInstruction` callback so consumers can opt in to handling generic PIs.

## API and behavior

```csharp
void OnProcessingInstruction(
    ReadOnlySpan<char> target,
    ReadOnlySpan<char> data,
    int line,
    int column)
```

- `target` is the PI target.
- `data` is the exact source text after `target` and before `?>`, including any separator whitespace, tabs, and line endings.
- A handler can reconstruct the original PI as `<?{target}{data}?>`.
- The callback has a default no-op implementation, preserving the existing behavior for handlers that do not need PIs.
- XML declarations remain exclusively routed to `OnXmlDeclaration`; they are not reported as generic PIs.
- The parser continues to reject malformed PIs and reserved `xml`-like targets according to its existing validation rules.

The callback follows the parser's existing `ReadOnlySpan<char>` event model, avoiding string allocation in the parser API.

## Why this matters

Consumers that retain unknown or extension XML for later serialization can currently lose a PI during parsing even when they preserve the surrounding elements and attributes. Reporting the PI makes lossless capture and round-tripping possible without changing the default behavior for existing consumers.

## Tests

Added regression coverage for:

- exact reconstruction, including whitespace, tabs, and CRLF data;
- PIs with no data;
- PIs inside element content;
- malformed PI rejection; and
- XML declaration routing remaining unchanged.

## Validation

```text
cd src
dotnet build -c Release
dotnet test -c Release
```