### PR TITLE
Add opt-in DTD ignoring

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ AMD Ryzen 9 7950X, 1 CPU, 32 logical and 16 physical cores
 
 This parser is following the [Extensible Markup Language (XML) 1.0 (Fifth Edition)](https://www.w3.org/TR/xml/) and **should support any XML valid documents**, except for the known limitations described below:
 
-- For simplicity of the implementation, this parser does not support DTD, custom entities and XML directives (`<!DOCTYPE ...>`). If you are looking for this, you should instead use `System.Xml.XmlReader`.
+- By default, this parser rejects DTD and XML directives (`<!DOCTYPE ...>`) and does not support custom entities. Set `XmlParserOptions.IgnoreDtd` to `true` to skip a legal DTD declaration without fetching external resources, processing DTD declarations, or expanding custom entities.
 - Generic processing instructions such as `<?xpacket ...?>` or `<?xml-stylesheet ...?>` trigger `IXmlReadHandler.OnProcessingInstruction`. Its default implementation is empty, so existing handlers continue to ignore them. The `data` callback parameter preserves the raw source after the target, including separating whitespace. Only the XML declaration `<?xml ...?>` triggers `IXmlReadHandler.OnXmlDeclaration`.
 - This parser checks for well formed XML, matching begin and end tags and report an error if they are not matching
 - This parser does not check for duplicated attributes.

--- a/src/TurboXml.Tests/XmlRuntimeTests.cs
+++ b/src/TurboXml.Tests/XmlRuntimeTests.cs
@@ -143,6 +143,87 @@ public class XmlRuntimeTests
     }
 
     [TestMethod]
+    public void TestDocumentTypeDeclarationIsRejectedByDefault()
+    {
+        var result = ParseEvents("""<!DOCTYPE root SYSTEM "file:///does-not-exist.dtd"><root/>""");
+
+        Assert.AreEqual("Error(Unsupported XML directive starting with !)", result);
+    }
+
+    [TestMethod]
+    public void TestDocumentTypeDeclarationCanBeIgnoredFromStringsAndStreams()
+    {
+        var options = new XmlParserOptions { IgnoreDtd = true };
+        var documentTypeDeclarations = new[]
+        {
+            "<!DOCTYPE root>",
+            """<!DOCTYPE root SYSTEM "file:///does-not-exist.dtd">""",
+            """<!DOCTYPE root PUBLIC "-//Example//DTD Root 1.0//EN" "file:///does-not-exist.dtd">""",
+            """<!DOCTYPE root [<!ELEMENT root (#PCDATA)><!ENTITY ignored "]>"><!-- ] --><?dtd-pi data?>]>""",
+        };
+        var expected = NormalizeNewLines(
+            """
+            BeginTag(root)
+            EndTagEmpty
+            """);
+
+        foreach (var documentTypeDeclaration in documentTypeDeclarations)
+        {
+            var xml = $"{documentTypeDeclaration}<root/>";
+            Assert.AreEqual(expected, ParseEvents(xml, options), documentTypeDeclaration);
+            Assert.AreEqual(expected, ParseStreamEvents(xml, options), documentTypeDeclaration);
+        }
+    }
+
+    [TestMethod]
+    public void TestProcessingInstructionInsideIgnoredDocumentTypeIsNotReported()
+    {
+        var handler = new ProcessingInstructionHandler();
+        const string xml = "<!DOCTYPE root [<?dtd-pi ignored?>]><?document-pi reported?><root/>";
+
+        XmlParser.Parse(xml, handler, new XmlParserOptions { IgnoreDtd = true });
+
+        Assert.HasCount(1, handler.Instructions);
+        Assert.AreEqual("document-pi", handler.Instructions[0].Target);
+        Assert.AreEqual(" reported", handler.Instructions[0].Data);
+    }
+
+    [TestMethod]
+    public void TestIgnoredDocumentTypeDoesNotDeclareEntities()
+    {
+        var result = ParseEvents(
+            """<!DOCTYPE root [<!ENTITY value "expanded">]><root>&value;</root>""",
+            new XmlParserOptions { IgnoreDtd = true });
+
+        Assert.AreEqual(
+            NormalizeNewLines(
+                """
+                BeginTag(root)
+                Error(Invalid entity name. Only &lt; or &gt; or &amp; or &apos; or &quot; are supported)
+                """),
+            result);
+    }
+
+    [TestMethod]
+    public void TestMalformedDocumentTypeDeclarationsAreRejectedWhenIgnored()
+    {
+        var options = new XmlParserOptions { IgnoreDtd = true };
+        var documents = new[]
+        {
+            "<!DOCTYPEroot><root/>",
+            "<!DOCTYPE root SYSTEM><root/>",
+            "<!DOCTYPE root [<!ELEMENT root ANY><root/>",
+            "<root/><!DOCTYPE root>",
+        };
+
+        foreach (var document in documents)
+        {
+            var result = ParseEvents(document, options);
+            Assert.IsTrue(result.Contains("Error(", StringComparison.Ordinal), result);
+        }
+    }
+
+    [TestMethod]
     public void TestXmlDeclarationMustRemainFirstAfterProcessingInstruction()
     {
         var xml = """<?xpacket begin="id"?><?xml version="1.0"?><root/>""";
@@ -407,10 +488,26 @@ public class XmlRuntimeTests
         return text.ReplaceLineEndings("\n").TrimEnd();
     }
 
-    private static string ParseEvents(string xml)
+    private static string ParseEvents(string xml, XmlParserOptions? options = null)
     {
         var handler = new XmlEventHandler { Writer = new StringWriter() };
-        XmlParser.Parse(xml, ref handler);
+        if (options.HasValue)
+        {
+            XmlParser.Parse(xml, ref handler, options.Value);
+        }
+        else
+        {
+            XmlParser.Parse(xml, ref handler);
+        }
+
+        return NormalizeNewLines(handler.Writer.ToString()!);
+    }
+
+    private static string ParseStreamEvents(string xml, XmlParserOptions options)
+    {
+        var handler = new XmlEventHandler { Writer = new StringWriter() };
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+        XmlParser.Parse(stream, ref handler, options);
         return NormalizeNewLines(handler.Writer.ToString()!);
     }
 

--- a/src/TurboXml/XmlParser.cs
+++ b/src/TurboXml/XmlParser.cs
@@ -23,6 +23,15 @@ public readonly record struct XmlParserOptions(Encoding? Encoding = null)
 
     /// <summary>Force using this encoding when parsing a stream. By default, TurboXml will detect the encoding by following the XML specs.</summary>
     public Encoding? Encoding { get; init; } = Encoding;
+
+    /// <summary>
+    /// Gets whether document type declarations are accepted and ignored.
+    /// </summary>
+    /// <remarks>
+    /// The default value is <see langword="false"/>, which rejects document type declarations. When <see langword="true"/>,
+    /// TurboXml skips the declaration without fetching external resources, processing DTD declarations, or expanding custom entities.
+    /// </remarks>
+    public bool IgnoreDtd { get; init; }
 }
 
 /// <summary>
@@ -45,7 +54,7 @@ public static class XmlParser
         var charProvider = new StreamCharProvider(stream, null);
         try
         {
-            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider);
+            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider, default);
             parser.Parse();
         }
         finally
@@ -68,7 +77,7 @@ public static class XmlParser
         var charProvider = new StreamCharProvider(stream, null);
         try
         {
-            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider);
+            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider, default);
             parser.Parse();
         }
         finally
@@ -90,7 +99,7 @@ public static class XmlParser
         ArgumentNullException.ThrowIfNull(handler);
 
         var charProvider = new StringCharProvider(text);
-        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider);
+        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider, default);
         parser.Parse();
     }
 
@@ -106,7 +115,7 @@ public static class XmlParser
         ArgumentNullException.ThrowIfNull(text);
 
         var charProvider = new StringCharProvider(text);
-        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider);
+        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider, default);
         parser.Parse();
     }
 
@@ -117,7 +126,8 @@ public static class XmlParser
     /// <param name="stream">The XML stream to parse.</param>
     /// <param name="handler">The handler to use to parse the XML.</param>
     /// <param name="options">The options to use to parse the XML.</param>
-    public static void Parse<TXmlHandler>(Stream stream, TXmlHandler handler, XmlParserOptions options)where TXmlHandler : class, IXmlReadHandler
+    public static void Parse<TXmlHandler>(Stream stream, TXmlHandler handler, XmlParserOptions options)
+        where TXmlHandler : class, IXmlReadHandler
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(handler);
@@ -125,7 +135,7 @@ public static class XmlParser
         var charProvider = new StreamCharProvider(stream, options.Encoding);
         try
         {
-            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider);
+            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider, options);
             parser.Parse();
         }
         finally
@@ -148,12 +158,47 @@ public static class XmlParser
         var charProvider = new StreamCharProvider(stream, options.Encoding);
         try
         {
-            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider);
+            using var parser = new XmlParserInternal<TXmlHandler, StreamCharProvider>(ref handler, ref charProvider, options);
             parser.Parse();
         }
         finally
         {
             charProvider.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Parses the specified XML string using the specified handler and options.
+    /// </summary>
+    /// <typeparam name="TXmlHandler">The type of the XML handler.</typeparam>
+    /// <param name="text">The XML text to parse.</param>
+    /// <param name="handler">The handler to use to parse the XML.</param>
+    /// <param name="options">The options to use to parse the XML.</param>
+    public static void Parse<TXmlHandler>(string text, TXmlHandler handler, XmlParserOptions options)
+        where TXmlHandler : class, IXmlReadHandler
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var charProvider = new StringCharProvider(text);
+        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider, options);
+        parser.Parse();
+    }
+
+    /// <summary>
+    /// Parses the specified XML string using the specified handler and options.
+    /// </summary>
+    /// <typeparam name="TXmlHandler">The type of the XML handler.</typeparam>
+    /// <param name="text">The XML text to parse.</param>
+    /// <param name="handler">The handler to use to parse the XML.</param>
+    /// <param name="options">The options to use to parse the XML.</param>
+    public static void Parse<TXmlHandler>(string text, ref TXmlHandler handler, XmlParserOptions options)
+        where TXmlHandler : struct, IXmlReadHandler
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        var charProvider = new StringCharProvider(text);
+        using var parser = new XmlParserInternal<TXmlHandler, StringCharProvider>(ref handler, ref charProvider, options);
+        parser.Parse();
     }
 }

--- a/src/TurboXml/XmlParserInternal.cs
+++ b/src/TurboXml/XmlParserInternal.cs
@@ -30,17 +30,22 @@ internal ref struct XmlParserInternal
     private int _contentLine;
     private int _contentColumn;
     private bool _xmlParsingBody;
+    private bool _isInProlog;
+    private bool _hasDocumentTypeDeclaration;
+    private readonly bool _ignoreDtd;
 
     private char[] _buffer;
     private int _length;
     private int _lastNameStackIndex;
 
-    public XmlParserInternal(ref THandler handler, ref TCharProvider stream)
+    public XmlParserInternal(ref THandler handler, ref TCharProvider stream, XmlParserOptions options)
     {
         _handler = ref handler;
         _stream = ref stream;
         _buffer = ArrayPool<char>.Shared.Rent(128);
         _column = -1;
+        _isInProlog = true;
+        _ignoreDtd = options.IgnoreDtd;
     }
 
     public void Dispose()
@@ -114,17 +119,24 @@ internal ref struct XmlParserInternal
                         }
                         else if (c == '[')
                         {
+                            _isInProlog = false;
                             ParseCData();
+                        }
+                        else if (c == 'D' && _ignoreDtd)
+                        {
+                            ParseDocumentTypeDeclaration();
                         }
                         else
                             ParseUnsupportedXmlDirective();
                     }
                     else if (c == '/')
                     {
+                        _isInProlog = false;
                         ParseEndTag();
                     }
                     else
                     {
+                        _isInProlog = false;
                         ParseBeginTag(c);
                     }
 
@@ -136,6 +148,7 @@ internal ref struct XmlParserInternal
                     break;
                 case '&':
                     _xmlParsingBody = true;
+                    _isInProlog = false;
                     ParseEntity(ref c);
                     break;
 
@@ -171,6 +184,10 @@ internal ref struct XmlParserInternal
 
                 default:
                     _xmlParsingBody = true;
+                    if (!XmlChar.IsWhiteSpace(c))
+                    {
+                        _isInProlog = false;
+                    }
 
                     if (XmlChar.IsChar(c))
                     {
@@ -686,6 +703,358 @@ internal ref struct XmlParserInternal
     private void ParseUnsupportedXmlDirective()
         => ThrowInvalidXml(XmlThrow.UnsupportedXmlDirective);
 
+    private void ParseDocumentTypeDeclaration()
+    {
+        if (!_isInProlog || _hasDocumentTypeDeclaration)
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+        _hasDocumentTypeDeclaration = true;
+
+        var c = 'D';
+        foreach (var expected in "OCTYPE")
+        {
+            c = ReadNext();
+            if (c != expected)
+                ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+        }
+
+        c = ReadNext();
+        ExpectSpaces(ref c);
+        if (!TryParseName(ref c))
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+        ClearCharacterBuffer();
+        SkipSpaces(ref c);
+
+        if (c == '>')
+            return;
+
+        if (c == '[')
+        {
+            ParseDtdInternalSubset();
+            return;
+        }
+
+        ParseDtdExternalId(ref c);
+        SkipSpaces(ref c);
+
+        if (c == '>')
+            return;
+
+        if (c == '[')
+        {
+            ParseDtdInternalSubset();
+            return;
+        }
+
+        ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+    }
+
+    private void ParseDtdExternalId(ref char c)
+    {
+        if (c == 'S')
+        {
+            ExpectDtdKeyword("SYSTEM", ref c);
+            ExpectSpaces(ref c);
+            ParseDtdLiteral(ref c, false);
+            return;
+        }
+
+        if (c == 'P')
+        {
+            ExpectDtdKeyword("PUBLIC", ref c);
+            ExpectSpaces(ref c);
+            ParseDtdLiteral(ref c, true);
+            ExpectSpaces(ref c);
+            ParseDtdLiteral(ref c, false);
+            return;
+        }
+
+        ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+    }
+
+    private void ExpectDtdKeyword(string keyword, ref char c)
+    {
+        foreach (var expected in keyword)
+        {
+            if (c != expected)
+                ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+            c = ReadNext();
+        }
+    }
+
+    private void ParseDtdLiteral(ref char c, bool isPublicIdentifier)
+    {
+        if (c != '"' && c != '\'')
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+        var delimiter = c;
+        while (true)
+        {
+            c = ReadNext();
+
+        ProcessCharacter:
+            if (c == delimiter)
+            {
+                c = ReadNext();
+                return;
+            }
+
+            switch (c)
+            {
+                case '\n':
+                    _line++;
+                    _column = -1;
+                    break;
+                case '\r':
+                    c = ReadNext();
+                    _line++;
+                    if (c == '\n')
+                    {
+                        _column = -1;
+                    }
+                    else
+                    {
+                        _column = 0;
+                        goto ProcessCharacter;
+                    }
+
+                    break;
+                default:
+                    if (XmlChar.IsChar(c) && (!isPublicIdentifier || IsPublicIdentifierChar(c)))
+                    {
+                        break;
+                    }
+
+                    if (char.IsHighSurrogate(c))
+                    {
+                        ReadLowSurrogate();
+                        break;
+                    }
+
+                    ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+                    break;
+            }
+        }
+    }
+
+    private void ParseDtdInternalSubset()
+    {
+        var c = ReadNext();
+        while (true)
+        {
+        ProcessCharacter:
+            switch (c)
+            {
+                case ']':
+                    c = ReadNext();
+                    SkipSpaces(ref c);
+                    if (c != '>')
+                        ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+                    return;
+                case '\'':
+                case '"':
+                    ParseDtdLiteral(ref c, false);
+                    goto ProcessCharacter;
+                case '<':
+                    c = ReadNext();
+                    if (c == '!')
+                    {
+                        c = ReadNext();
+                        if (c == '-')
+                        {
+                            ParseDtdComment();
+                        }
+                        else
+                        {
+                            ParseDtdMarkupDeclaration(ref c);
+                        }
+                    }
+                    else if (c == '?')
+                    {
+                        ParseDtdProcessingInstruction();
+                    }
+                    else
+                    {
+                        ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+                    }
+
+                    break;
+                case '\n':
+                    _line++;
+                    _column = -1;
+                    break;
+                case '\r':
+                    c = ReadNext();
+                    _line++;
+                    if (c == '\n')
+                    {
+                        _column = -1;
+                    }
+                    else
+                    {
+                        _column = 0;
+                        goto ProcessCharacter;
+                    }
+
+                    break;
+                default:
+                    if (XmlChar.IsChar(c))
+                    {
+                        break;
+                    }
+
+                    if (char.IsHighSurrogate(c))
+                    {
+                        ReadLowSurrogate();
+                        break;
+                    }
+
+                    ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+                    break;
+            }
+
+            c = ReadNext();
+        }
+    }
+
+    private void ParseDtdMarkupDeclaration(ref char c)
+    {
+        while (true)
+        {
+        ProcessCharacter:
+            switch (c)
+            {
+                case '>':
+                    return;
+                case '\'':
+                case '"':
+                    ParseDtdLiteral(ref c, false);
+                    goto ProcessCharacter;
+                case '\n':
+                    _line++;
+                    _column = -1;
+                    break;
+                case '\r':
+                    c = ReadNext();
+                    _line++;
+                    if (c == '\n')
+                    {
+                        _column = -1;
+                    }
+                    else
+                    {
+                        _column = 0;
+                        goto ProcessCharacter;
+                    }
+
+                    break;
+                default:
+                    if (XmlChar.IsChar(c))
+                    {
+                        break;
+                    }
+
+                    if (char.IsHighSurrogate(c))
+                    {
+                        ReadLowSurrogate();
+                        break;
+                    }
+
+                    ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+                    break;
+            }
+
+            c = ReadNext();
+        }
+    }
+
+    private void ParseDtdComment()
+    {
+        if (ReadNext() != '-')
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+        while (true)
+        {
+            var c = ReadNext();
+
+        ProcessCharacter:
+            switch (c)
+            {
+                case '-':
+                    c = ReadNext();
+                    if (c == '-')
+                    {
+                        if (ReadNext() != '>')
+                            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+                        return;
+                    }
+
+                    goto ProcessCharacter;
+                case '\n':
+                    _line++;
+                    _column = -1;
+                    break;
+                case '\r':
+                    c = ReadNext();
+                    _line++;
+                    if (c == '\n')
+                    {
+                        _column = -1;
+                    }
+                    else
+                    {
+                        _column = 0;
+                        goto ProcessCharacter;
+                    }
+
+                    break;
+                default:
+                    if (XmlChar.IsCommentChar(c))
+                    {
+                        break;
+                    }
+
+                    if (char.IsHighSurrogate(c))
+                    {
+                        ReadLowSurrogate();
+                        break;
+                    }
+
+                    ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+                    break;
+            }
+        }
+    }
+
+    private void ParseDtdProcessingInstruction()
+    {
+        var c = ReadNext();
+        if (!TryParseName(ref c))
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+
+        var target = GetTextSpan();
+        if (target.Length == 3
+            && (target[0] == 'x' || target[0] == 'X')
+            && (target[1] == 'm' || target[1] == 'M')
+            && (target[2] == 'l' || target[2] == 'L'))
+        {
+            ThrowInvalidXml(XmlThrow.InvalidDocumentTypeDeclaration);
+        }
+
+        ClearCharacterBuffer();
+        ParseProcessingInstruction(0, 0, 0, 0, ref c, false);
+    }
+
+    private static bool IsPublicIdentifierChar(char c)
+    {
+        return char.IsAsciiLetterOrDigit(c)
+            || c is ' ' or '\r' or '\n' or '-' or '\'' or '(' or ')' or '+' or ',' or '.' or '/' or ':' or '=' or '?' or ';' or '!' or '*' or '#' or '@' or '$' or '_' or '%';
+    }
+
     private void ParseCData()
     {
         char c;
@@ -921,7 +1290,7 @@ internal ref struct XmlParserInternal
         ParseProcessingInstruction(targetStart, targetLength, startLine, startColumn, ref c);
     }
 
-    private void ParseProcessingInstruction(int targetStart, int targetLength, int startLine, int startColumn, ref char c)
+    private void ParseProcessingInstruction(int targetStart, int targetLength, int startLine, int startColumn, ref char c, bool reportInstruction = true)
     {
         var dataStart = _length;
         var hasDataSeparator = XmlChar.IsWhiteSpace(c);
@@ -930,12 +1299,17 @@ internal ref struct XmlParserInternal
             c = ReadNext();
             if (c == '>')
             {
-                _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), ReadOnlySpan<char>.Empty, startLine, startColumn);
+                if (reportInstruction)
+                {
+                    _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), ReadOnlySpan<char>.Empty, startLine, startColumn);
+                }
+
                 ClearCharacterBuffer();
                 return;
             }
 
-            AppendCharacter('?');
+            if (reportInstruction)
+                AppendCharacter('?');
         }
 
         while (true)
@@ -950,17 +1324,25 @@ internal ref struct XmlParserInternal
                         if (!hasDataSeparator)
                             ThrowInvalidXml(XmlThrow.InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan);
 
-                        _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), GetTextSpan(dataStart), startLine, startColumn);
+                        if (reportInstruction)
+                        {
+                            _handler.OnProcessingInstruction(GetTextSpan(targetStart).Slice(0, targetLength), GetTextSpan(dataStart), startLine, startColumn);
+                        }
+
                         ClearCharacterBuffer();
                         return;
                     }
 
-                    AppendCharacter('?');
+                    if (reportInstruction)
+                        AppendCharacter('?');
+
                     goto ProcessNextChar;
                 case '\n':
                     _line++;
                     _column = -1;
-                    AppendCharacter(c);
+                    if (reportInstruction)
+                        AppendCharacter(c);
+
                     break;
                 case '\r':
                     if (!TryReadNext(out c))
@@ -970,13 +1352,18 @@ internal ref struct XmlParserInternal
                     if (c == '\n')
                     {
                         _column = -1;
-                        AppendCharacter('\r');
-                        AppendCharacter(c);
+                        if (reportInstruction)
+                        {
+                            AppendCharacter('\r');
+                            AppendCharacter(c);
+                        }
                     }
                     else
                     {
                         _column = 0;
-                        AppendCharacter('\r');
+                        if (reportInstruction)
+                            AppendCharacter('\r');
+
                         goto ProcessNextChar;
                     }
 
@@ -984,14 +1371,21 @@ internal ref struct XmlParserInternal
                 default:
                     if (XmlChar.IsChar(c))
                     {
-                        AppendCharacter(c);
+                        if (reportInstruction)
+                            AppendCharacter(c);
+
                         break;
                     }
 
                     if (char.IsHighSurrogate(c))
                     {
-                        AppendCharacter(c);
-                        AppendCharacter(ReadLowSurrogate());
+                        var lowSurrogate = ReadLowSurrogate();
+                        if (reportInstruction)
+                        {
+                            AppendCharacter(c);
+                            AppendCharacter(lowSurrogate);
+                        }
+
                         break;
                     }
 

--- a/src/TurboXml/XmlThrowHelper.cs
+++ b/src/TurboXml/XmlThrowHelper.cs
@@ -45,7 +45,8 @@ internal enum XmlThrow
     InvalidCharacterFoundExpectingQuestionGreaterThan,
     InvalidEndOfXMLStream,
     InvalidCharacterFoundExpectingLowSurrogate,
-    InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan
+    InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan,
+    InvalidDocumentTypeDeclaration
 }
 
 internal static class XmlThrowHelper
@@ -101,6 +102,7 @@ internal static class XmlThrowHelper
             XmlThrow.InvalidEndOfXMLStream => "Invalid end of XML stream",
             XmlThrow.InvalidCharacterFoundExpectingLowSurrogate => "Invalid character found. Expecting a low surrogate",
             XmlThrow.InvalidProcessingInstructionExpectingWhitespaceOrQuestionGreaterThan => "Invalid processing instruction. Expecting whitespace or ?> after the target",
+            XmlThrow.InvalidDocumentTypeDeclaration => "Invalid document type declaration",
             _ => "Unexpected XML parsing error"
         };
     }


### PR DESCRIPTION
## Summary

TurboXml currently rejects every `<!DOCTYPE ...>` declaration. Some consumers intentionally use the `XmlReaderSettings.DtdProcessing = Ignore` model instead: accept a legal document containing a DOCTYPE, but do not load, interpret, or expand its DTD.

This PR adds that narrow, opt-in behavior without adding general DTD support.

## API

```csharp
var options = new XmlParserOptions
{
    IgnoreDtd = true,
};
```

`IgnoreDtd` defaults to `false`, so the current secure behavior—rejecting DOCTYPE declarations—remains unchanged. Matching string `XmlParser.Parse` overloads accepting `XmlParserOptions` are also added, bringing them in line with the stream overloads.

## Behavior when enabled

The parser recognizes and skips the lexical form of legal document type declarations, including:

- a simple `<!DOCTYPE root>` declaration;
- `SYSTEM` external identifiers;
- `PUBLIC` identifiers;
- quoted literals; and
- internal subsets containing markup declarations, comments, and processing instructions.

It deliberately does **not**:

- retrieve external DTDs or other resources;
- process or validate DTD declarations;
- make declared entities available; or
- expand custom entities.

Consequently, `&custom;` remains an error even if it was declared inside the skipped internal subset. This preserves the parser's existing entity model and prevents the option from becoming a DTD-processing or resource-resolution feature.

Malformed DOCTYPE syntax is still rejected. This is a safe acceptance mode for callers that explicitly need `DtdProcessing.Ignore`-style compatibility, not general DTD support.

## Tests

Added regression coverage for:

- default DOCTYPE rejection;
- opt-in parsing through both string and stream paths;
- simple, `SYSTEM`, `PUBLIC`, and internal-subset declarations;
- malformed declaration rejection; and
- proof that an ignored internal subset does not declare or expand custom entities.

## Validation

```text
cd src
dotnet build -c Release
dotnet test -c Release
```